### PR TITLE
feat: update macos version in deployment-ios job

### DIFF
--- a/.github/workflows/app-ios.yml
+++ b/.github/workflows/app-ios.yml
@@ -92,7 +92,7 @@ jobs:
             ios/build/bundle/
 
   deployment-ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     name: Build 🔨 the iOs ipa and deploy 🚀 when the branch is one of the environments
     needs: [prepare-environment, build-ios]
     if: ${{ needs.prepare-environment.outputs.should_deploy == 'true' }}


### PR DESCRIPTION
# [JIRA-ID]

## What changes does this PR introduce

- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Test

## Any background context you want to provide

Warning de Apple Store:
`This app was built with the iOS 16.2 SDK. Starting April 29, 2024, all iOS and iPadOS apps must be built with the iOS 17 SDK or later, included in Xcode 15 or later, in order to be uploaded to App Store Connect or submitted for distribution.`

Se cambia la versión de macos para poder compilar con Xcode 15.