### PR TITLE
feat: add QEMU setup for ARM emulation in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-service-ruff-uv.yml
+++ b/.github/workflows/python-service-ruff-uv.yml
@@ -141,6 +141,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Set up QEMU (for ARM emulation)
+        if: ${{ needs.prepare.outputs.should_release == 'true' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Deploy the server 🚀
         if: ${{ needs.prepare.outputs.should_release == 'true' }}
         run: cd '${{ inputs.service }}' && npm run deploy


### PR DESCRIPTION
- Introduced a step to set up QEMU for ARM emulation, enabling deployment compatibility for ARM64 platforms when the release condition is met.
