### PR TITLE
fix: python-library - update mypy command to use --package for full package analysis

### DIFF
--- a/.github/workflows/python-library.yml
+++ b/.github/workflows/python-library.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run additional python checks
         run: |
           cd '${{ inputs.library }}'
-          uv run mypy --ignore-missing-imports --scripts-are-modules -m taxdown
+          uv run mypy --ignore-missing-imports --scripts-are-modules --package taxdown
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This change updates the mypy invocation in the GitHub workflow by replacing -m taxdown with --package taxdown in the .github/workflows/python-library.yml file. With this update, mypy will recursively analyze the entire taxdown package (including all submodules), instead of only the main module as defined in __init__.py. This ensures a more comprehensive static analysis and helps catch issues in all parts of the code.