### PR TITLE
ci: update web-deploy configuration to use role instead of access keys

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -12,9 +12,7 @@ on:
         required: true
         type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
+      AWS_DEPLOYMENT_ROLE:
         required: true
       NPM_TOKEN:
         required: true
@@ -63,10 +61,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOYMENT_ROLE }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Set NPM registry
@@ -88,17 +85,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_CI_SECRET_ACCESS_KEY }}
 
       - name: Run linter
         run: npm run lint
 
       - name: Run tests
         run: npm run test
-        env:
-          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_CI_SECRET_ACCESS_KEY }}
 
       - name: Deploy the server 🚀
         run: npm run deploy
-        env:
-          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_CI_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# [INFRA-625]

## What changes does this PR introduce

- [X] Feature
- [ ] Fix
- [ ] Refactor
- [x] Chore
- [ ] Docs
- [ ] Test

# Descripción
Actualiza la configuración de despliegue web para utilizar roles IAM en lugar de claves de acceso

## Cambios
- Modifica la configuración del despliegue web para utilizar roles IAM
- Elimina el uso de claves de acceso directas mejorando la seguridad
- Implementa las mejores prácticas de AWS para la gestión de credenciales

## Tipo de cambio
- [x] Mejora de seguridad
- [x] Mejora en CI/CD

## Pruebas
- [ ] Verificar que el despliegue funciona correctamente con los roles IAM
- [ ] Comprobar que los permisos del rol son los adecuados
- [ ] Validar el flujo completo de CI/CD en ambiente de staging

## Notas adicionales
Este cambio mejora la seguridad al eliminar el uso de claves de acceso estáticas y seguir las mejores prácticas recomendadas por AWS para la gestión de credenciales en pipelines de CI/CD.