### PR TITLE
ci: remove legacy serverless key requirement from web-deploy configuration

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -18,8 +18,6 @@ on:
         required: true
       SENTRY_AUTH_TOKEN:
         required: true
-      SERVERLESS_CI_SECRET_ACCESS_KEY:
-        required: true
 
 jobs:
   prepare:


### PR DESCRIPTION
# [INFRA-625]

## What changes does this PR introduce

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [X] Chore
- [ ] Docs
- [ ] Test

# Descripción
Elimina el requerimiento de SERVERLESS_CI_SECRET_ACCESS_KEY de la configuración de despliegue web

## Cambios
- Elimina la dependencia de la clave de acceso secreta de Serverless CI
- Simplifica la configuración del despliegue web
- Continúa con la migración hacia un modelo basado en roles IAM