### PR TITLE
ci: add serverless key as optional in web-deploy configuration

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -18,6 +18,8 @@ on:
         required: true
       SENTRY_AUTH_TOKEN:
         required: true
+      SERVERLESS_CI_SECRET_ACCESS_KEY:
+        required: false
 
 jobs:
   prepare:
@@ -92,3 +94,5 @@ jobs:
 
       - name: Deploy the server 🚀
         run: npm run deploy
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_CI_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# [INFRA-625]

## What changes does this PR introduce

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Test

# Descripción
Hace opcional la clave de acceso de Serverless CI en la configuración de despliegue web

## Cambios
- Modifica la configuración para hacer `SERVERLESS_CI_SECRET_ACCESS_KEY` opcional
- Mantiene compatibilidad con el flujo de despliegue existente
- Permite la coexistencia de autenticación por roles y claves de acceso
