### PR TITLE
fix: update macOS version for iOS deployment workflow

### DIFF
--- a/.github/workflows/app-ios.yml
+++ b/.github/workflows/app-ios.yml
@@ -92,7 +92,7 @@ jobs:
             ios/build/bundle/
 
   deploy:
-    runs-on: macos-13
+    runs-on: macos-14
     name: Build 🔨 the iOs ipa and deploy 🚀 when the branch is one of the environments
     needs: [prepare, build]
     if: ${{ needs.prepare.outputs.should_deploy == 'true' }}


### PR DESCRIPTION
# [MAC-994]

## What changes does this PR introduce

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Test

## Cambios Principales
- Actualización del runner de macOS de la versión anterior a `macos-14` en el job de deploy
- Mantenimiento de la compatibilidad con el resto de la configuración del workflow

## Detalles Técnicos
1. **Workflow de iOS**:
   - Modificación del runner en el job `deploy` para usar `macos-14`
   - No se requieren cambios adicionales en la configuración del workflow

2. **Impacto**:
   - Mejora en la estabilidad del proceso de build
   - Acceso a las últimas herramientas y dependencias de macOS
   - Mantenimiento de la compatibilidad con las versiones actuales de Xcode

## Referencias y Screenshots
- [GitHub Actions macOS Runner Versions](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software)
- [Actualizaciones de requisitos de Apple](https://developer.apple.com/news/upcoming-requirements/?id=02212025a)
- [Declaración de funciones de salud en Google Play](https://support.google.com/googleplay/android-developer/answer/13996367?hl=es)