### PR TITLE
fix: remove --ignore-scripts flag from npm ci commands in workflow files

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -70,7 +70,7 @@ jobs:
           scope: '@taxdown'
 
       - name: Installing NPM dependencies on production mode
-        run: npm ci --ignore-scripts
+        run: npm ci
         env:
           # NODE_ENV: production # disabled until we figure out a way of making the build deps (esbuild, glob, typescript, etc.) to load
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -77,7 +77,7 @@ jobs:
           scope: '@taxdown'
 
       - name: Installing NPM dependencies on production mode
-        run: cd '${{ inputs.package-path }}' && npm ci --ignore-scripts
+        run: cd '${{ inputs.package-path }}' && npm ci
         env:
           # NODE_ENV: production # disabled until we figure out a way of making the build deps (esbuild, glob, typescript, etc.) to load
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🐛 Problema
Los workflows de npm estaban usando la flag `--ignore-scripts` en los comandos `npm ci`, lo que impedía la ejecución de scripts npm necesarios durante la instalación de dependencias en producción.

## 🔧 Solución
- Eliminado `--ignore-scripts` del step de instalación de dependencias en `npm-package.yml`
- Eliminado `--ignore-scripts` del step de instalación de dependencias en `npm-packages.yml`

## 📋 Cambios
- **npm-package.yml**: Line 73 - `npm ci --ignore-scripts` → `npm ci`
- **npm-packages.yml**: Line 80 - `npm ci --ignore-scripts` → `npm ci`

## ✅ Resultado
Los scripts npm ahora se ejecutarán correctamente durante el proceso de deploy en ambos workflows.