### PR TITLE
feat: create update-submodules action with authentication support

### DIFF
--- a/.github/actions/update-submodules/README.md
+++ b/.github/actions/update-submodules/README.md
@@ -1,0 +1,45 @@
+# Update Submodules Action
+
+GitHub Action to update git submodules with authentication support and flexible strategies.
+
+## Usage
+
+```yaml
+- name: Update submodules
+  uses: taxdown/.github/.github/actions/update-submodules@main
+  with:
+    strategy: commit
+    token: ${{ steps.app-token.outputs.token }}
+```
+
+## Inputs
+
+- `strategy`: Strategy to use (commit or tag), defaults to 'commit'
+- `token`: GitHub token for authentication (required)
+
+## Strategies
+
+### Commit Strategy (default)
+Updates submodules to the latest commit on their configured branch:
+```yaml
+strategy: commit
+```
+
+### Tag Strategy
+Updates submodules to their latest tag:
+```yaml
+strategy: tag
+```
+
+## What it does
+
+- Configures Git authentication for submodule operations
+- Supports both commit and tag-based updates
+- Handles recursive submodule updates
+- Uses Git's native submodule configuration
+- Works with private repositories
+
+## Requirements
+
+- Requires a valid GitHub token with appropriate permissions
+- Must be run after checkout with submodules

--- a/.github/actions/update-submodules/action.yml
+++ b/.github/actions/update-submodules/action.yml
@@ -1,0 +1,47 @@
+name: 'Update Submodules'
+description: 'Update git submodules to their latest commits or tags'
+
+inputs:
+  strategy:
+    description: 'Strategy to use (commit or tag)'
+    required: false
+    default: 'commit'
+  token:
+    description: 'GitHub token for authentication'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Update submodules
+      shell: bash
+      env:
+        GIT_TOKEN: ${{ inputs.token }}
+      run: |
+        echo "Updating submodules using strategy: ${{ inputs.strategy }}"
+        
+        # Configure Git authentication for this step
+        export GIT_ASKPASS=/tmp/.git-askpass
+        echo 'echo $GIT_TOKEN' > $GIT_ASKPASS
+        chmod +x $GIT_ASKPASS
+        
+        # Configure Git to use HTTPS with the token
+        git config --global url."https://github.com/".insteadOf "https://github.com/"
+        git config --global url."https://github.com/".insteadOf "git@github.com:"
+        git config --global url."https://github.com/".insteadOf "ssh://git@github.com"
+        
+        if [[ "${{ inputs.strategy }}" == "tag" ]]; then
+          echo "Configuring submodules to use latest tags..."
+          # Configure each submodule to use the latest tag
+          git submodule foreach --recursive 'git config submodule.$name.update "!git fetch --tags && git checkout \$(git describe --tags --abbrev=0)"'
+          # Update submodules with the new configuration
+          git submodule update --init --recursive --remote
+        else
+          echo "Using default branch tracking..."
+          # Reset to default checkout behavior
+          git submodule foreach --recursive 'git config submodule.$name.update checkout'
+          # Update submodules with default behavior
+          git submodule update --init --recursive --remote
+        fi
+        
+        echo "Submodules updated successfully"


### PR DESCRIPTION
# ¿Qué cambios introduce este PR? ✨

- [X] ✨ Feature

## Descripción
Este PR introduce una nueva acción de GitHub para actualizar submódulos de git con soporte de autenticación y estrategias flexibles. Esta funcionalidad es útil para mantener los submódulos actualizados de manera automática, lo que puede ser beneficioso para desarrolladores y equipos que trabajan con repositorios que contienen submódulos.

## Detalles de los cambios
Se ha creado una nueva acción de GitHub llamada 'Update Submodules' que permite actualizar los submódulos de un repositorio a sus últimos commits o tags. La acción soporta dos estrategias: 'commit' y 'tag'. La estrategia por defecto es 'commit', que actualiza los submódulos al último commit en su rama configurada. La estrategia 'tag' actualiza los submódulos a su última etiqueta.

La acción requiere un token de GitHub para la autenticación, asegurando que las operaciones de submódulos se realicen de manera segura, incluso en repositorios privados. Se ha incluido un archivo README detallado que explica cómo usar la acción, los inputs requeridos, y las estrategias disponibles.

Además, se ha configurado la autenticación de Git para operaciones de submódulos y se ha asegurado que la acción maneje actualizaciones recursivas de submódulos, utilizando la configuración nativa de submódulos de Git.