### PR TITLE
feat: add submodules support to python service workflow

### DIFF
--- a/.github/workflows/python-service-ruff-uv.yml
+++ b/.github/workflows/python-service-ruff-uv.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Update submodules
         if: ${{ inputs.update-submodules }}
-        uses: ./.github/actions/update-submodules
+        uses: taxdown/.github/.github/actions/update-submodules@main
         with:
           strategy: ${{ inputs.submodule-strategy }}
           token: ${{ steps.app-token.outputs.token }}
@@ -220,7 +220,7 @@ jobs:
 
       - name: Update submodules
         if: ${{ inputs.update-submodules }}
-        uses: ./.github/actions/update-submodules
+        uses: taxdown/.github/.github/actions/update-submodules@main
         with:
           strategy: ${{ inputs.submodule-strategy }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/python-service-ruff-uv.yml
+++ b/.github/workflows/python-service-ruff-uv.yml
@@ -20,6 +20,16 @@ on:
         description: 'Github app id'
         type: string
         required: true
+      update-submodules:
+        description: 'Whether to update submodules (default: false)'
+        required: false
+        type: boolean
+        default: false
+      submodule-strategy:
+        description: 'Strategy for submodule updates (commit or tag)'
+        required: false
+        type: string
+        default: 'commit'
     secrets:
       AWS_DEPLOYMENT_ROLE:
         required: true
@@ -84,6 +94,13 @@ jobs:
           app-id: ${{ inputs.github-app-id }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+
+      - name: Update submodules
+        if: ${{ inputs.update-submodules }}
+        uses: ./.github/actions/update-submodules
+        with:
+          strategy: ${{ inputs.submodule-strategy }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -200,6 +217,13 @@ jobs:
           app-id: ${{ inputs.github-app-id }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+
+      - name: Update submodules
+        if: ${{ inputs.update-submodules }}
+        uses: ./.github/actions/update-submodules
+        with:
+          strategy: ${{ inputs.submodule-strategy }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node & NPM registry
         uses: actions/setup-node@v4


### PR DESCRIPTION
# ¿Qué cambios introduce este PR? ✨ Feature

- [X] ✨ Feature

## Descripción
Este PR introduce soporte para la actualización de submódulos en el flujo de trabajo de servicios Python. Esto permite que los desarrolladores gestionen submódulos dentro de sus proyectos de manera más eficiente, asegurando que siempre estén actualizados según la estrategia definida.

## Detalles de los cambios
Se han añadido dos nuevos parámetros de entrada al flujo de trabajo: `update-submodules` y `submodule-strategy`. El primero es un booleano que determina si se deben actualizar los submódulos, mientras que el segundo especifica la estrategia de actualización (por commit o por tag).

Se ha integrado una nueva acción `update-submodules` en los trabajos de construcción y prueba, así como en los de despliegue. Esta acción se ejecuta condicionalmente, dependiendo del valor del parámetro `update-submodules`. Además, se utiliza el token de la aplicación de GitHub existente para la autenticación, manteniendo la compatibilidad con servicios que no utilizan submódulos.

Estos cambios permiten una mayor flexibilidad y control sobre la gestión de submódulos en los proyectos, facilitando su mantenimiento y actualización.