### PR TITLE
feat: add workflow_dispatch support to node-service-iam workflow

### DIFF
--- a/.github/workflows/node-service-iam.yml
+++ b/.github/workflows/node-service-iam.yml
@@ -36,6 +36,9 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/${{inputs.service}}-v* ]] ; then
               echo "matrix=[\"prod\"]" >> $GITHUB_OUTPUT
               echo "should_release=true" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              echo "should_release=true" >> $GITHUB_OUTPUT
+              echo "matrix=[\"dev\"]" >> $GITHUB_OUTPUT
           else
               echo "matrix=[\"staging\"]" >> $GITHUB_OUTPUT
               echo "should_release=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# ¿Qué cambios introduce este PR? ✨

- [X] ✨ Feature

## Descripción
Este PR introduce la capacidad de activar manualmente el flujo de trabajo `node-service-iam` mediante el evento `workflow_dispatch`. Esto permite a los desarrolladores desplegar manualmente en el entorno de desarrollo (`dev`) para facilitar pruebas y desarrollo.

## Detalles de los cambios
Se ha modificado el archivo de flujo de trabajo `.github/workflows/node-service-iam.yml` para incluir una nueva condición que verifica si el evento que dispara el flujo de trabajo es `workflow_dispatch`. En caso afirmativo, se establece la variable `should_release` en `true` y se configura el despliegue en el entorno `dev`. Esto proporciona flexibilidad adicional para realizar despliegues manuales en el entorno de desarrollo, lo cual es útil para pruebas y ajustes antes de realizar despliegues en entornos de producción o staging.