### PR TITLE
feat: add manual workflow dispatch support to node-service-iam

### DIFF
--- a/.github/workflows/node-service-iam.yml
+++ b/.github/workflows/node-service-iam.yml
@@ -36,6 +36,9 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/${{inputs.service}}-v* ]] ; then
               echo "matrix=[\"prod\"]" >> $GITHUB_OUTPUT
               echo "should_release=true" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              echo "should_release=true" >> $GITHUB_OUTPUT
+              echo "matrix=[\"dev\"]" >> $GITHUB_OUTPUT
           else
               echo "matrix=[\"staging\"]" >> $GITHUB_OUTPUT
               echo "should_release=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# ¿Qué cambios introduce este PR? ✨ Feature

- [X] ✨ Feature

## Descripción
Este PR introduce la capacidad de activar manualmente el flujo de trabajo `node-service-iam` en GitHub Actions. Esto permite a los desarrolladores desplegar manualmente en el entorno de desarrollo (`dev`) para realizar pruebas, proporcionando flexibilidad adicional en el proceso de despliegue.

## Detalles de los cambios
Se ha añadido soporte para eventos `workflow_dispatch` en el archivo de configuración del flujo de trabajo `.github/workflows/node-service-iam.yml`. Cuando el flujo de trabajo se activa manualmente, se establece la variable `should_release` en `true` y se configura el despliegue para el entorno `dev`. Esto permite a los desarrolladores realizar pruebas en un entorno controlado antes de proceder a otros entornos como `staging` o `prod`.