### PR TITLE
fix(workflows): pin claude-code-action to specific commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
## ¿Qué cambios introduce este PR?
🔧 Configuración

## Descripción

### ¿Qué problema resuelve?
El workflow de Claude Code Review usa `anthropics/claude-code-action@v1`, una referencia mutable que puede cambiar sin previo aviso, lo que supone un riesgo de supply chain.

### ¿Cómo lo resuelve?
Pinea la GitHub Action a un commit SHA específico (`6e2bd52842c65e914eba5c8badd17560bd26b5de`) en lugar de usar el tag `v1`.

### ¿Qué impacto tiene?
Mayor seguridad y reproducibilidad en el pipeline de CI. Las actualizaciones de la action serán ahora explícitas y revisables.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)