### PR TITLE
chore(ci): bump iOS deploy runner to macos-26 for Xcode 26

### DIFF
--- a/.github/workflows/app-ios.yml
+++ b/.github/workflows/app-ios.yml
@@ -98,7 +98,7 @@ jobs:
             ios/build/bundle/
 
   deploy:
-    runs-on: macos-15
+    runs-on: macos-26
     name: Build 🔨 the iOs ipa and deploy 🚀 when the branch is one of the environments
     needs: [prepare, build]
     if: ${{ needs.prepare.outputs.should_deploy == 'true' }}


### PR DESCRIPTION
## ¿Qué cambios introduce este PR?
🔧 Configuración

## Descripción

### ¿Qué problema resuelve?
Apple endureció el requisito para subir builds a App Store Connect: a partir de mayo 2026 cualquier IPA debe estar compilada con el iOS 26 SDK o superior. El runner actual \`macos-15\` trae Xcode 16.x (iPhoneOS 18.5 SDK) y \`altool\` rechaza el upload con error 409 \"SDK version issue\". Como consecuencia ningún release de prod iOS puede salir hasta resolverlo. Detectado al intentar subir broly 5.8.0.

### ¿Cómo lo resuelve?
Cambia el runner del job \`deploy\` de \`macos-15\` a \`macos-26\`, que trae Xcode 26.2 por defecto (también disponibles 26.0.1, 26.1.1, 26.3, 26.4.1, 26.5 beta). El binario resultante apunta a iPhoneOS 26.x SDK y \`altool\` lo acepta sin tocar nada del codebase. Las builds de dev/staging (Firebase) no se ven afectadas funcionalmente — Firebase no valida la versión del SDK.

### ¿Qué impacto tiene?
- Aplica a todos los repos que consumen \`taxdown/.github/.github/workflows/app-ios.yml@main\`. Próximas releases iOS volverán a subir a App Store Connect.
- Validado en broly: build local con Xcode 26.3 (SDK 26.2) corre OK en device, CI con \`macos-26\` genera IPA aceptado por \`altool\`, smoke test runtime sin regresiones.
- Sin breaking changes en la API del workflow.

## Testing
- [x] Build local en broly contra Xcode 26.3 (SDK 26.2) — runtime OK en iPhone físico
- [x] CI con runner \`macos-26\` en rama \`release/dev/test-xcode-26\` — Firebase recibe build
- [x] CI con runner \`macos-26\` en \`release/prod/5.8.0\` — \`altool\` acepta upload, build 582 procesado por TestFlight como \"Ready to Submit\"