### PR TITLE
fix(ci): pin Xcode 26.2 for the iOS deploy job

### DIFF
--- a/.github/workflows/app-ios.yml
+++ b/.github/workflows/app-ios.yml
@@ -107,6 +107,13 @@ jobs:
     env:
       STAGE: ${{ needs.prepare.outputs.environment }}
     steps:
+      # Pin Xcode explicitly: the macos-26 image ships several Xcodes and
+      # GitHub floats the default (26.2 -> 26.4.x -> 26.2). Xcode 26.4's Clang
+      # breaks fmt (consteval) and the Segment pod (private header), so pin
+      # 26.2 -- the toolchain the last successful App Store build shipped with.
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Check out source code
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## ¿Qué cambios introduce este PR?
🐛 Corrección de error

## Descripción

### ¿Qué problema resuelve?
El job `deploy` de `app-ios.yml` nunca seleccionaba una versión de Xcode, así que usaba la que GitHub pusiera por defecto en la imagen `macos-26`. Esa imagen lleva varios Xcodes instalados (26.2, 26.3, 26.4.1, 26.5β) y GitHub **flota el default**. Al moverse a Xcode 26.4.1, su Clang/SDK más estricto rompió el build de deploy de iOS de las apps consumidoras:

- `fmt 11.0.2`: `call to consteval function ... is not a constant expression` (ver [react-native#55601](https://github.com/facebook/react-native/issues/55601), [fmtlib/fmt#4740](https://github.com/fmtlib/fmt/issues/4740))
- Segment `analytics-ios`: `use of private header from outside its module: netinet6/in6.h` (ver [analytics-ios#1069](https://github.com/segmentio/analytics-ios/issues/1069))

### ¿Cómo lo resuelve?
Añade un paso `Select Xcode 26.2` al inicio del job `deploy` que hace `xcode-select` a `/Applications/Xcode_26.2.app` — versión confirmada como instalada en la imagen `macos-26`. Es el toolchain con el que se subieron las últimas builds a las stores correctamente.

### ¿Qué impacto tiene?
El build de iOS pasa a ser **determinista**: deja de depender del default flotante de GitHub. Sortea de golpe los fallos de `fmt` y de `Analytics` con Xcode 26.4, sin parchear pods. Es un fix temporal razonable hasta que React Native suba `fmt` a 12.x; el día que Xcode 26.4+ sea obligatorio por requisito de Apple habrá que revisar este pin.

## Detalles de Cambios

- `.github/workflows/app-ios.yml` — nuevo paso `Select Xcode 26.2` en el job `deploy`.

> ⚠️ **Scope**: workflow compartido — aplica a **todas las apps** que usan `app-ios.yml` (broly, etc.). Pin conservador a una versión ya instalada y probada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)