### PR TITLE
fix(submodules): persist resolved SHAs from build to deploy

### DIFF
--- a/.github/actions/update-submodules/README.md
+++ b/.github/actions/update-submodules/README.md
@@ -14,8 +14,11 @@ GitHub Action to update git submodules with authentication support and flexible 
 
 ## Inputs
 
-- `strategy`: Strategy to use (commit or tag), defaults to 'commit'
+- `strategy`: Strategy to use (`commit`, `tag`, `init`, or `locked`), defaults to `commit`
 - `token`: GitHub token for authentication (required)
+- `lock-file`: Path to a submodule SHA lock file (optional). For `commit`/`tag`/`init`
+  the resolved `<path>\t<sha>` pairs are written here after updating; for `locked` the
+  file is read and each submodule is pinned to its exact SHA.
 
 ## Strategies
 
@@ -29,6 +32,52 @@ strategy: commit
 Updates submodules to their latest tag:
 ```yaml
 strategy: tag
+```
+
+### Init Strategy
+Checks out the revisions pinned (the gitlink) in the parent repository:
+```yaml
+strategy: init
+```
+
+### Locked Strategy
+Checks out each submodule (detached) to the exact SHA recorded in a lock file and
+fails if the resulting HEAD does not match. Pair it with `lock-file` produced by an
+earlier `commit`/`tag` run so a later job deploys the same revision that was tested:
+```yaml
+strategy: locked
+lock-file: ${{ runner.temp }}/submodule-lock.txt
+```
+
+## Persisting SHAs across jobs
+
+To guarantee a `deploy` job uses the exact submodule revisions resolved by
+`build-and-test`, write a lock in the build job, publish it as an artifact, and
+consume it in deploy:
+
+```yaml
+# build-and-test
+- uses: taxdown/.github/.github/actions/update-submodules@main
+  with:
+    strategy: commit
+    token: ${{ steps.app-token.outputs.token }}
+    lock-file: ${{ runner.temp }}/submodule-lock.txt
+- uses: actions/upload-artifact@v4
+  with:
+    name: submodule-lock
+    path: ${{ runner.temp }}/submodule-lock.txt
+    if-no-files-found: error
+
+# deploy
+- uses: actions/download-artifact@v4
+  with:
+    name: submodule-lock
+    path: ${{ runner.temp }}
+- uses: taxdown/.github/.github/actions/update-submodules@main
+  with:
+    strategy: locked
+    token: ${{ steps.app-token.outputs.token }}
+    lock-file: ${{ runner.temp }}/submodule-lock.txt
 ```
 
 ## Technical Design Decisions

--- a/.github/actions/update-submodules/action.yml
+++ b/.github/actions/update-submodules/action.yml
@@ -191,11 +191,18 @@ runs:
 
             # Fetch the exact commit; fall back to a full fetch if the server does
             # not allow fetching an arbitrary SHA directly.
-            git -C "$sub_path" fetch origin "$sub_sha" 2>/dev/null \
-              || git -C "$sub_path" fetch origin || {
-                echo "Error: failed to fetch $sub_sha for $sub_path"
+            if ! git -C "$sub_path" fetch origin "$sub_sha" 2>/dev/null; then
+              echo "Direct SHA fetch failed for $sub_path; fetching origin refs..."
+              git -C "$sub_path" fetch origin || {
+                echo "Error: failed to fetch origin for $sub_path; check network/authentication"
                 exit 1
               }
+              if ! git -C "$sub_path" cat-file -e "$sub_sha^{commit}" 2>/dev/null; then
+                echo "Error: locked SHA $sub_sha for $sub_path is not available after fetching origin"
+                echo "The tested commit may have been force-pushed/pruned; re-run build to generate a fresh lock."
+                exit 1
+              fi
+            fi
 
             git -C "$sub_path" checkout --detach "$sub_sha" || {
               echo "Error: failed to checkout $sub_sha for $sub_path"
@@ -289,7 +296,42 @@ runs:
           echo "Writing submodule SHA lock to: $LOCK_FILE"
           : > "$LOCK_FILE"
           git submodule --quiet foreach --recursive \
-            'printf "%s\t%s\n" "$displaypath" "$(git rev-parse HEAD)"' >> "$LOCK_FILE"
+            'sub_sha=$(git rev-parse HEAD) || {
+               echo "Error: failed to resolve HEAD for $displaypath" >&2
+               exit 1
+             }
+             if [[ -z "$displaypath" || -z "$sub_sha" ]]; then
+               echo "Error: malformed submodule lock entry for $displaypath" >&2
+               exit 1
+             fi
+             printf "%s\t%s\n" "$displaypath" "$sub_sha"' >> "$LOCK_FILE" || {
+            echo "Error: failed to write submodule SHA lock"
+            exit 1
+          }
+
+          expected_entries=$(git submodule --quiet foreach --recursive 'printf "%s\n" "$displaypath"' | wc -l | tr -d ' ')
+          actual_entries=0
+          while IFS=$'\t' read -r sub_path sub_sha extra || [[ -n "${sub_path:-}" ]]; do
+            if [[ -z "${sub_path:-}" || -z "${sub_sha:-}" || -n "${extra:-}" ]]; then
+              echo "Error: malformed lock entry: $sub_path"
+              exit 1
+            fi
+            if [[ ! -d "$sub_path" ]]; then
+              echo "Error: lock entry path '$sub_path' not found in working tree"
+              exit 1
+            fi
+            if ! git -C "$sub_path" cat-file -e "$sub_sha^{commit}" 2>/dev/null; then
+              echo "Error: lock SHA for $sub_path is not a local commit: $sub_sha"
+              exit 1
+            fi
+            actual_entries=$((actual_entries + 1))
+          done < "$LOCK_FILE"
+
+          if [[ "$actual_entries" -ne "$expected_entries" ]]; then
+            echo "Error: lock contains $actual_entries entries but $expected_entries submodule(s) were found"
+            exit 1
+          fi
+
           echo "Submodule lock contents:"
           cat "$LOCK_FILE"
         fi

--- a/.github/actions/update-submodules/action.yml
+++ b/.github/actions/update-submodules/action.yml
@@ -3,12 +3,21 @@ description: 'Update git submodules to their latest commits or tags'
 
 inputs:
   strategy:
-    description: 'Strategy to use: "commit" (latest remote commit), "tag" (latest tag), or "init" (pinned revision in parent repo)'
+    description: 'Strategy to use: "commit" (latest remote commit), "tag" (latest tag), "init" (pinned revision in parent repo), or "locked" (exact SHAs from a lock file)'
     required: false
     default: 'commit'
   token:
     description: 'GitHub token for authentication'
     required: true
+  lock-file:
+    description: |
+      Path to a submodule SHA lock file. Behaviour depends on the strategy:
+      - "commit"/"tag"/"init": if set, the resolved "<path>\t<sha>" pairs are written
+        to this file after updating, so a downstream job can pin the exact same SHAs.
+      - "locked": the file is read and each submodule is checked out (detached) to its
+        exact SHA, failing if the resulting HEAD does not match the lock.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -18,12 +27,13 @@ runs:
       env:
         GIT_TOKEN: ${{ inputs.token }}
         STRATEGY: ${{ inputs.strategy }}
+        LOCK_FILE: ${{ inputs.lock-file }}
       run: |
         # Exit on error, undefined variables, and pipe failures
         set -euo pipefail
         
-        # Lock file to prevent race conditions
-        LOCK_FILE="/tmp/git-submodule-update-$$.lock"
+        # Mutex file to prevent race conditions (distinct from the SHA LOCK_FILE input)
+        MUTEX_FILE="/tmp/git-submodule-update-$$.lock"
         
         # Function to acquire lock
         acquire_lock() {
@@ -59,7 +69,7 @@ runs:
         cleanup() {
           echo "Cleaning up..."
           rm -f "$GIT_ASKPASS" 2>/dev/null || true
-          release_lock "$LOCK_FILE"
+          release_lock "$MUTEX_FILE"
           # Restore original Git config - clean up only what we set
           git config --global --unset-all url."https://x-access-token:$GIT_TOKEN@github.com/".insteadOf "https://github.com/" 2>/dev/null || true
           git config --global --unset-all url."https://x-access-token:$GIT_TOKEN@github.com/".insteadOf "git@github.com:" 2>/dev/null || true
@@ -70,7 +80,7 @@ runs:
         trap cleanup EXIT
         
         # Acquire lock to prevent race conditions
-        acquire_lock "$LOCK_FILE" || {
+        acquire_lock "$MUTEX_FILE" || {
           echo "Error: Failed to acquire lock. Another instance may be running."
           exit 1
         }
@@ -100,14 +110,20 @@ runs:
         check_existing_config
         
         # Validate strategy input
-        if [[ "$STRATEGY" != "commit" && "$STRATEGY" != "tag" && "$STRATEGY" != "init" ]]; then
-          echo "Error: Invalid strategy '$STRATEGY'. Must be 'commit', 'tag', or 'init'"
+        if [[ "$STRATEGY" != "commit" && "$STRATEGY" != "tag" && "$STRATEGY" != "init" && "$STRATEGY" != "locked" ]]; then
+          echo "Error: Invalid strategy '$STRATEGY'. Must be 'commit', 'tag', 'init', or 'locked'"
           exit 1
         fi
-        
+
         # Check if submodules exist
         if [[ ! -f .gitmodules ]]; then
           echo "No submodules found in this repository"
+          # Still emit an (empty) lock when writing, so downstream jobs that always
+          # expect the artifact keep working for repos without submodules.
+          if [[ -n "$LOCK_FILE" && "$STRATEGY" != "locked" ]]; then
+            : > "$LOCK_FILE"
+            echo "Wrote empty submodule lock to $LOCK_FILE"
+          fi
           exit 0
         fi
         
@@ -139,7 +155,64 @@ runs:
           }
         fi
         
-        if [[ "$STRATEGY" == "init" ]]; then
+        if [[ "$STRATEGY" == "locked" ]]; then
+          echo "Restoring submodules from lock file..."
+
+          if [[ -z "$LOCK_FILE" ]]; then
+            echo "Error: strategy 'locked' requires the 'lock-file' input"
+            exit 1
+          fi
+          if [[ ! -f "$LOCK_FILE" ]]; then
+            echo "Error: lock file not found: $LOCK_FILE"
+            exit 1
+          fi
+
+          # Make sure submodule repositories are initialised before pinning.
+          git submodule update --init --recursive || {
+            echo "Error: Failed to initialize submodules"
+            exit 1
+          }
+
+          pinned=0
+          while IFS=$'\t' read -r sub_path sub_sha || [[ -n "${sub_path:-}" ]]; do
+            # Skip blank lines and comments
+            [[ -z "${sub_path:-}" ]] && continue
+            [[ "$sub_path" == \#* ]] && continue
+            if [[ -z "${sub_sha:-}" ]]; then
+              echo "Error: malformed lock entry for '$sub_path' (missing SHA)"
+              exit 1
+            fi
+
+            echo "Pinning $sub_path -> $sub_sha"
+            if [[ ! -d "$sub_path" ]]; then
+              echo "Error: submodule path '$sub_path' from lock not found in working tree"
+              exit 1
+            fi
+
+            # Fetch the exact commit; fall back to a full fetch if the server does
+            # not allow fetching an arbitrary SHA directly.
+            git -C "$sub_path" fetch origin "$sub_sha" 2>/dev/null \
+              || git -C "$sub_path" fetch origin || {
+                echo "Error: failed to fetch $sub_sha for $sub_path"
+                exit 1
+              }
+
+            git -C "$sub_path" checkout --detach "$sub_sha" || {
+              echo "Error: failed to checkout $sub_sha for $sub_path"
+              exit 1
+            }
+
+            actual_sha=$(git -C "$sub_path" rev-parse HEAD)
+            if [[ "$actual_sha" != "$sub_sha" ]]; then
+              echo "Error: $sub_path resolved to $actual_sha but lock expected $sub_sha"
+              exit 1
+            fi
+            echo "  - $sub_path: $actual_sha (verified)"
+            pinned=$((pinned + 1))
+          done < "$LOCK_FILE"
+
+          echo "Pinned $pinned submodule(s) from lock file"
+        elif [[ "$STRATEGY" == "init" ]]; then
           echo "Checking out pinned revisions from parent repo..."
 
           git submodule update --init --recursive || {
@@ -209,5 +282,16 @@ runs:
             echo "  - $displaypath: $commit_hash ($commit_msg)"
           '
         fi
-        
+
+        # Persist the resolved SHAs to a lock file so a later job (e.g. deploy) can
+        # pin the submodules to the exact same revisions that were just resolved.
+        if [[ -n "$LOCK_FILE" && "$STRATEGY" != "locked" ]]; then
+          echo "Writing submodule SHA lock to: $LOCK_FILE"
+          : > "$LOCK_FILE"
+          git submodule --quiet foreach --recursive \
+            'printf "%s\t%s\n" "$displaypath" "$(git rev-parse HEAD)"' >> "$LOCK_FILE"
+          echo "Submodule lock contents:"
+          cat "$LOCK_FILE"
+        fi
+
         echo "Submodules updated successfully"

--- a/.github/workflows/python-service-uv-v2.yml
+++ b/.github/workflows/python-service-uv-v2.yml
@@ -141,7 +141,10 @@ jobs:
           name: submodule-lock-${{ matrix.stage }}
           path: ${{ runner.temp }}/submodule-lock.txt
           if-no-files-found: error
-          retention-days: 1
+          # 7 days so a failed deploy can be re-run days later without losing the
+          # lock; overwrite avoids the v4 409 conflict on "re-run all jobs".
+          overwrite: true
+          retention-days: 7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/python-service-uv-v2.yml
+++ b/.github/workflows/python-service-uv-v2.yml
@@ -124,6 +124,13 @@ jobs:
           github-app-id: ${{ inputs.github-app-id }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
 
+      - name: Validate build submodule strategy
+        if: ${{ inputs.update-submodules && inputs.submodule-strategy != 'commit' && inputs.submodule-strategy != 'tag' }}
+        run: |
+          echo "Error: build submodule-strategy must be 'commit' or 'tag' when update-submodules is enabled"
+          echo "Deploy uses the build-generated lock, so 'init' and 'locked' are not valid build strategies here."
+          exit 1
+
       - name: Update submodules
         if: ${{ inputs.update-submodules }}
         uses: taxdown/.github/.github/actions/update-submodules@main

--- a/.github/workflows/python-service-uv-v2.yml
+++ b/.github/workflows/python-service-uv-v2.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Update submodules
         if: ${{ inputs.update-submodules }}
-        uses: taxdown/.github/.github/actions/update-submodules@albertoarmijo/dat-2370
+        uses: taxdown/.github/.github/actions/update-submodules@main
         with:
           strategy: ${{ inputs.submodule-strategy }}
           token: ${{ steps.github-auth.outputs.token }}
@@ -243,7 +243,7 @@ jobs:
 
       - name: Restore submodules from lock
         if: ${{ inputs.update-submodules }}
-        uses: taxdown/.github/.github/actions/update-submodules@albertoarmijo/dat-2370
+        uses: taxdown/.github/.github/actions/update-submodules@main
         with:
           strategy: locked
           token: ${{ steps.github-auth.outputs.token }}

--- a/.github/workflows/python-service-uv-v2.yml
+++ b/.github/workflows/python-service-uv-v2.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Update submodules
         if: ${{ inputs.update-submodules }}
-        uses: taxdown/.github/.github/actions/update-submodules@main
+        uses: taxdown/.github/.github/actions/update-submodules@albertoarmijo/dat-2370
         with:
           strategy: ${{ inputs.submodule-strategy }}
           token: ${{ steps.github-auth.outputs.token }}
@@ -243,7 +243,7 @@ jobs:
 
       - name: Restore submodules from lock
         if: ${{ inputs.update-submodules }}
-        uses: taxdown/.github/.github/actions/update-submodules@main
+        uses: taxdown/.github/.github/actions/update-submodules@albertoarmijo/dat-2370
         with:
           strategy: locked
           token: ${{ steps.github-auth.outputs.token }}

--- a/.github/workflows/python-service-uv-v2.yml
+++ b/.github/workflows/python-service-uv-v2.yml
@@ -130,6 +130,18 @@ jobs:
         with:
           strategy: ${{ inputs.submodule-strategy }}
           token: ${{ steps.github-auth.outputs.token }}
+          lock-file: ${{ runner.temp }}/submodule-lock.txt
+
+      # Publish the SHAs resolved above so the deploy job pins the exact same
+      # submodule revisions that were built and tested here (see DAT-2370).
+      - name: Upload submodule lock
+        if: ${{ inputs.update-submodules }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: submodule-lock-${{ matrix.stage }}
+          path: ${{ runner.temp }}/submodule-lock.txt
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -214,15 +226,25 @@ jobs:
           github-app-id: ${{ inputs.github-app-id }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
 
-      # Always use "init" in deploy to pin submodules to the exact SHA committed in
-      # the parent repo — guarantees deploy runs the same code that passed tests,
-      # regardless of what has been pushed to the submodule remote since then.
-      - name: Initialize submodules
+      # Pin submodules to the exact SHAs resolved by build-and-test. The gitlink
+      # committed in the parent repo can lag behind, so relying on it ("init") let
+      # deploy bake a different revision than the one that passed tests (DAT-2370).
+      # download-artifact fails if the lock is missing, so deploy never silently
+      # falls back to a divergent revision.
+      - name: Download submodule lock
+        if: ${{ inputs.update-submodules }}
+        uses: actions/download-artifact@v4
+        with:
+          name: submodule-lock-${{ matrix.stage }}
+          path: ${{ runner.temp }}
+
+      - name: Restore submodules from lock
         if: ${{ inputs.update-submodules }}
         uses: taxdown/.github/.github/actions/update-submodules@main
         with:
-          strategy: init
+          strategy: locked
           token: ${{ steps.github-auth.outputs.token }}
+          lock-file: ${{ runner.temp }}/submodule-lock.txt
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## ¿Qué cambios introduce este PR?
🐛 Corrección de error

## Descripción

### ¿Qué problema resuelve?
En el reusable `python-service-uv-v2.yml`, el job `build-and-test` resolvía el submódulo (`apollo/src/cintra`) al último commit de `cintra/main` con `strategy: commit`, pero el job `deploy` hacía un checkout limpio y usaba `strategy: init` (el gitlink pineado en el repo padre). Como el update del build no se persistía ni se comunicaba al deploy, CI validaba una versión de Cintra y producción horneaba otra distinta (evidenciado en los releases `apollo-v0.29.0` y `apollo-v0.30.1`).

### ¿Cómo lo resuelve?
Se amplía la action compartida `update-submodules` con:
- Un input `lock-file` que, tras resolver con `commit`/`tag`/`init`, escribe un lock `<path>\t<sha>` por submódulo (recursivo).
- Una nueva estrategia `locked` que lee ese lock, hace `fetch` del SHA exacto, `checkout --detach`, y **falla si el HEAD resultante no coincide**.

En el reusable, `build-and-test` publica el lock como artifact `submodule-lock-<stage>` (`if-no-files-found: error`) y `deploy` lo descarga (download-artifact falla si falta) y ejecuta `update-submodules` con `strategy: locked`. Así, aunque `cintra/main` avance entre build y deploy, deploy despliega exactamente el SHA que pasó tests. Se mantiene la forma del pipeline (`build-and-test` + `deploy`), sin nuevos stages.

Además se renombró la variable interna del mutex de concurrencia (`LOCK_FILE` → `MUTEX_FILE`) para evitar colisión con el nuevo input.

### ¿Qué impacto tiene?
Los deploys de Apollo dejan de rebobinar Cintra: build y deploy usan el mismo SHA de submódulo. Las estrategias `commit`/`tag`/`init` quedan intactas y el reusable hermano `python-service-ruff-uv.yml` (que no pasa `lock-file`) conserva su comportamiento previo. Repos sin submódulos escriben un lock vacío para no romper el artifact.

## Issues de Linear
Closes DAT-2370

## Detalles de Cambios
### Archivos modificados
- `.github/actions/update-submodules/action.yml` — input `lock-file`, estrategia `locked`, escritura del lock, rename del mutex.
- `.github/actions/update-submodules/README.md` — documentación de `init`, `locked` y persistencia de SHAs entre jobs.
- `.github/workflows/python-service-uv-v2.yml` — `build-and-test` sube el lock por stage; `deploy` lo descarga y aplica `strategy: locked`.

## Testing
- Test end-to-end local con el script extraído de la action (repo padre + submódulo + remoto bare): `commit` escribe el lock; tras avanzar `main`, `locked` fija el SHA del build (no el nuevo); lock ausente y SHA divergente fallan explícitamente; repo sin submódulos escribe lock vacío.
- `actionlint` limpio en `python-service-uv-v2.yml`.
- `shellcheck` sin hallazgos salvo SC2016 intencional en cuerpos `git submodule foreach`.